### PR TITLE
fix(webapp/store): injected report destructuring

### DIFF
--- a/src/analyze-files.js
+++ b/src/analyze-files.js
@@ -54,8 +54,9 @@ function findCommonPath(splitFilePaths = []) {
 }
 
 export default function analyzeFiles(filesCoverage) {
-  const files = Object.keys(filesCoverage)
-    .map(filePath => analyzeFile(filePath, filesCoverage[filePath]));
+  const filePaths = Object.keys(filesCoverage);
+  if (!filePaths.length) { return []; }
+  const files = filePaths.map(filePath => analyzeFile(filePath, filesCoverage[filePath]));
   const splitFullFilePaths = files.map(file => file.path.split('/'));
   const commonPath = findCommonPath(splitFullFilePaths).join('/');
   return files.map(file => {

--- a/src/webapp/store.js
+++ b/src/webapp/store.js
@@ -6,14 +6,16 @@ import buildTree from './services/build-tree';
 import {locationAction} from './actions/location-action';
 import reportReducer from './reducers/report-reducer';
 
-const {files = [], timestamp, thresholds, environment} = '%REPORT%';
+let report = '%REPORT%';
+report = typeof report === 'string' ? {files: []} : report;
+
 const store = createStore(reportReducer, {
   location: parseUrl(window.location.href),
-  files: buildTree(files),
-  filepaths: files.map(f => f.path),
-  environment,
-  thresholds,
-  timestamp
+  files: buildTree(report.files),
+  filepaths: report.files.map(f => f.path),
+  environment: report.environment,
+  thresholds: report.thresholds,
+  timestamp: report.timestamp
 });
 
 window.addEventListener('hashchange', ({newURL}) => {


### PR DESCRIPTION
When the report is injected (by text replace) babel has already transformed the code to ES5 where destructuring does not exist. So we cannot destructure directly and must assign report to a variable first.